### PR TITLE
Fixed whitespace replace in text content

### DIFF
--- a/src/Openbuildings/Spiderling/Driver/Selenium.php
+++ b/src/Openbuildings/Spiderling/Driver/Selenium.php
@@ -142,8 +142,7 @@ class Driver_Selenium extends Driver {
 	public function text($id)
 	{
 		$text = $this->connection()->get("element/$id/text");
-		$text = preg_replace('/[\t\n\r]/', ' ', $text);
-		$text = preg_replace('/\s\s+/', ' ', $text);
+		$text = preg_replace('/\s+/', ' ', $text);
 		return trim($text);
 	}
 

--- a/src/Openbuildings/Spiderling/Driver/Simple.php
+++ b/src/Openbuildings/Spiderling/Driver/Simple.php
@@ -267,7 +267,7 @@ class Driver_Simple extends Driver {
 	public function text($id)
 	{
 		$text = $this->dom($id)->textContent;
-		$text = preg_replace('/([\t\n\r]|\s\s+| )/', ' ', $text);
+		$text = preg_replace('/\s+/', ' ', $text);
 		
 		return trim($text);
 	}

--- a/tests/tests/Driver/SimpleTest.php
+++ b/tests/tests/Driver/SimpleTest.php
@@ -97,8 +97,8 @@ class Driver_SimpleTest extends Spiderling_TestCase {
 		$html = $this->driver->html("//textarea[@id='post_body']");
 		$this->assertEquals('<textarea name="post[body]" id="post_body" cols="30" rows="10">Lorem Ipsum</textarea>', $html);
 
-		$text = $this->driver->text("//textarea[@id='post_body']");
-		$this->assertEquals('Lorem Ipsum', $text);
+		$text = $this->driver->text("//div[@id='text']");
+		$this->assertEquals('Lorem Ipsum Dolor Sit Amet', $text);
 
 		$value = $this->driver->value("//input[@id='post_title']");
 		$this->assertEquals('Title 1', $value);

--- a/tests/views/form.html
+++ b/tests/views/form.html
@@ -84,5 +84,15 @@
 			<button id='search-btn' type="submit">Search</button>
 		</form>
 	</div>
+
+	<div id="text">
+		   Lorem
+
+
+
+
+					<strong>Ipsum</strong>
+					Dolor   Sit 		<span>Amet</span>
+	</div>
 </body>
 </html>


### PR DESCRIPTION
When there are repetitive tabs or new lines they should all be replaced with a single space character.

Also the `text()` method in the Selenium driver could have the same replacement with a single regular expression.
