### PR TITLE
Support visiting URIs with an implicit query

### DIFF
--- a/src/Openbuildings/Spiderling/Driver.php
+++ b/src/Openbuildings/Spiderling/Driver.php
@@ -326,4 +326,23 @@ abstract class Driver {
 		return $this->page;
 	}
 
+	/**
+	 * Extract implicit query from URI
+	 *
+	 * @return array
+	 */
+	public static function extract_query_from_uri($uri)
+	{
+		$uri_query_str = parse_url($uri, PHP_URL_QUERY);
+
+		if ( ! $uri_query_str)
+		{
+			return array();
+		}
+
+		parse_str($uri_query_str, $uri_query);
+
+		return $uri_query;
+	}
+
 }

--- a/src/Openbuildings/Spiderling/Driver/Phantomjs.php
+++ b/src/Openbuildings/Spiderling/Driver/Phantomjs.php
@@ -268,6 +268,14 @@ class Driver_Phantomjs extends Driver {
 		$query = array_merge((array) $this->_next_query, (array) $query);
 
 		$this->_next_query = NULL;
+
+		// Check for implicit query string
+		if (strpos($uri, '?') !== FALSE)
+		{
+			$query = array_merge(self::extract_query_from_uri($uri), $query);
+			$uri = substr($uri, 0, strpos($uri, '?'));
+		}
+
 		$url = $this->base_url().$uri.($query ? '?'.http_build_query($query) : '');
 
 		$this->connection()->post('url', array('value' => $url));

--- a/src/Openbuildings/Spiderling/Driver/Selenium.php
+++ b/src/Openbuildings/Spiderling/Driver/Selenium.php
@@ -298,6 +298,14 @@ class Driver_Selenium extends Driver {
 		$query = array_merge((array) $this->_next_query, (array) $query);
 
 		$this->_next_query = NULL;
+
+		// Check for implicit query string
+		if (strpos($uri, '?') !== FALSE)
+		{
+			$query = array_merge(self::extract_query_from_uri($uri), $query);
+			$uri = substr($uri, 0, strpos($uri, '?'));
+		}
+
 		$url = $this->base_url().$uri.($query ? '?'.http_build_query($query) : '');
 
 		$this->connection()->post('url', array('url' => $url));


### PR DESCRIPTION
We could pass the result of a function call to `visit()` and it would be really good if Spiderling supports such URLs rather than separating the query from the URI every time `visit()` is used.