### PR TITLE
Fixed typographical error, changed appart to apart in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ Loads the HTML page with curl and then parses it using PHP's native DOM and XPat
 
 Before each request $_GET, $_POST and $_FILES are saved, filled in with appropriate values and later restored, mimicking a real PHP request.
 
-Appart from loading the HTML through curl, you could set the content directly, if you've loaded it by other means.
+Apart from loading the HTML through curl, you could set the content directly, if you've loaded it by other means.
 
 Here's how that looks:
 


### PR DESCRIPTION
@OpenBuildings, I've corrected a typographical error in the documentation of the [spiderling](https://github.com/OpenBuildings/spiderling) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.