### PR TITLE
Fire "change" event on form value set

### DIFF
--- a/assets/phantomjs-connection.js
+++ b/assets/phantomjs-connection.js
@@ -102,6 +102,8 @@ var PhantomjsConnection = (function (document, undefined) {
 			elem.focus();
 			elem.value = value;
 			elem.blur();
+
+			this.fireEvent(elem, 'change');
 		},
 
 		/**


### PR DESCRIPTION
Filling a form on a page, when the form is rendered using React component is not working as the PhantomJS driver does not fire a change event in a React controlled form elements.
Proposing a fix for that.